### PR TITLE
Avoid accumulating error callbacks for failed workers start 

### DIFF
--- a/src/ensureStartWorker.js
+++ b/src/ensureStartWorker.js
@@ -56,7 +56,9 @@ export default function ensureStart(debugStrategy, workers, instance, cb) {
     instance.starting = false;
 
     if (startErr) {
-      instance.startCb.forEach((callback) => callback(startErr));
+      let startCbs = instance.startCb.slice(0);
+      instance.startCb.splice(0, instance.startCb.length);
+      startCbs.forEach((callback) => callback(startErr));
       return;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ function rmDir(dirPath) {
     for (let ix = 0; ix < files.length; ix++) {
       let filePath = `${dirPath}/${files[ix]}`;
 
-      if (fs.lstatSync(filePath).isFile()) {
+      if (fs.statSync(filePath).isFile()) {
         fs.unlinkSync(filePath);
       }
     }
@@ -59,7 +59,7 @@ describe('electron html to pdf', () => {
   function common(strategy) {
     let conversion = createConversion(strategy);
 
-    afterEach(() => {
+    after(() => {
       rmDir(tmpDir);
     });
 


### PR DESCRIPTION
I was experiencing duplicit callback calls on `conversion`. It turned out that if the workers fails to start, the second call invokes the first callback again.

Additionally this PR also adds explicit file stream closing to tests which fixes it on windows.